### PR TITLE
fix: mapping current dir to docker /app dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build: .
     volumes:
       - data:/app/data/
+      - .:/app/
     ports:
       - "8000:8000"
     env_file:


### PR DESCRIPTION
I just change the docker-compose to map the current directory to  the /app of docker to avoid extra build commands